### PR TITLE
Fixed msbuild failure due to add-path deprecation

### DIFF
--- a/.github/workflows/aspnet.yml
+++ b/.github/workflows/aspnet.yml
@@ -36,7 +36,7 @@ jobs:
       run: nuget restore
   
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
       #with:
       #  vs-version: "[16.4,16.5]"  #Version of Visual Studio to search; defaults to latest if not specified
 


### PR DESCRIPTION
v1.0.0 relies on the deprecated add-path function. More recent releases have fixed this issue.